### PR TITLE
Fix type mismatch

### DIFF
--- a/ftok.go
+++ b/ftok.go
@@ -12,5 +12,6 @@ func Ftok(path string, id uint64) (uint64, error) {
 	if err := syscall.Stat(path, st); err != nil {
 		return 0, err
 	}
-	return ((st.Ino & 0xffff) | ((st.Dev & 0xff) << 16) | ((id & 0xff) << 24)), nil
+	return uint64((st.Ino & 0xffff) | uint64((st.Dev & 0xff) << 16) | 
+		((id & 0xff) << 24)), nil
 }


### PR DESCRIPTION
siadat/ipc/ftok.go:15: invalid operation: st.Ino & 65535 | st.Dev & 255 << 16 (mismatched types uint64 and int32)