### PR TITLE
Use IPC_INFO to get msgmax size

### DIFF
--- a/cmd/ipcctl/main.go
+++ b/cmd/ipcctl/main.go
@@ -90,6 +90,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+	default:
+		log.Fatalf("Unsupported option %s\n", os.Args[1])
 	}
 }
 

--- a/common.go
+++ b/common.go
@@ -1,5 +1,9 @@
 package ipc
 
+import (
+	"math/bits"
+)
+
 const (
 	// https://code.woboq.org/userspace/glibc/sysdeps/unix/sysv/linux/bits/ipc.h.html
 	// Mode bits for `msgget', `semget', and `shmget'.
@@ -17,16 +21,14 @@ const (
 	IPC_PRIVATE = 0 // Private key. NOTE: this value is of type __key_t, i.e., ((__key_t) 0)
 )
 
-const (
-	bufSize = 8192
-)
+var msgmax = 8192  // default size, will be overriden during init to match system msgmax
+var uintSize = bits.UintSize / 8 // size of a uint, arch dependent
 
 type Msgbuf struct {
 	Mtype uint
 	Mtext []byte
 }
 
-type msgbufInternal struct {
-	Mtype uint
-	Mtext [bufSize]byte
+func Msgmax() int {
+	return msgmax
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/siadat/ipc
+
+go 1.14

--- a/init_linux.go
+++ b/init_linux.go
@@ -1,0 +1,31 @@
+package ipc
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func init() {
+	var buf msginfo
+	_, _, err := syscall.Syscall(
+		syscall.SYS_MSGCTL, 
+		0, 
+		uintptr(IPC_INFO), 
+		uintptr(unsafe.Pointer(&buf)))
+	if err != 0 {
+		return // can't read current msg info, leave defaults
+	}
+
+	msgmax = int(buf.msgmax)
+}
+
+type msginfo struct {
+    msgpool int32
+    msgmap int32
+    msgmax int32
+    msgmnb int32
+    msgmni int32
+    msgssz int32
+    msgtql int32
+    msgseg uint16
+}

--- a/msgrcv_test.go
+++ b/msgrcv_test.go
@@ -41,7 +41,7 @@ func TestMsgrcv(t *testing.T) {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to send message to ipc id %d: %s\n", qid, err))
 	} else {
-		fmt.Printf("Message %v send to ipc id %d\n", input, qid)
+		fmt.Printf("Message %x send to ipc id %d\n", input, qid)
 	}
 
 	qbuf := &ipc.Msgbuf{Mtype: 12}
@@ -51,7 +51,7 @@ func TestMsgrcv(t *testing.T) {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to receive message to ipc id %d: %s\n", qid, err))
 	} else {
-		fmt.Printf("Message %v receive to ipc id %d\n", qbuf.Mtext, qid)
+		fmt.Printf("Message %x receive to ipc id %d\n", qbuf.Mtext, qid)
 	}
 
 	if !bytes.Equal(input, qbuf.Mtext) {

--- a/msgsnd_test.go
+++ b/msgsnd_test.go
@@ -40,7 +40,6 @@ func TestMsgsnd(t *testing.T) {
 				t.Fatal(err)
 			}
 		}(qid)
-
 		mtext := "hello"
 		done := make(chan struct{})
 		go func() {
@@ -52,6 +51,7 @@ func TestMsgsnd(t *testing.T) {
 			if want, got := mtext, string(qbuf.Mtext); want != got {
 				t.Fatalf("want %#v, got %#v", want, got)
 			}
+			fmt.Printf("Received: %s\n", string(qbuf.Mtext))
 			done <- struct{}{}
 		}()
 


### PR DESCRIPTION
On linux, at package init, call IPC_INFO and retrieve msgmax (the configured size of a message)
Use this size to create the buffers to send and receive messages
Since we can't create a packed structure with a slice, use binary.Read/Write to mashall the data into a []byte for syscall

Since IPC_INFO may not be supported on all OSes, it's restricted to linux in this PR, and the default 8192 bytes value is kept on the other systems (or if the call fails)
 