### PR TITLE
add possibility of preparing and sending a message

### DIFF
--- a/msgsnd.go
+++ b/msgsnd.go
@@ -10,8 +10,51 @@ import (
 
 // Msgsnd calls the msgsnd() syscall.
 func Msgsnd(qid uint, msg *Msgbuf, flags uint) error {
+	buffer, err := PrepareMsg(msg)
+	if err != nil {
+		return err
+	}
+
+	return MsgsndPrepared(qid, len(msg.Mtext), buffer, flags)
+}
+
+
+// 	if len(msg.Mtext) > msgmax {
+// 		return fmt.Errorf("mtext is too large, %d > %d", len(msg.Mtext), msgmax)
+// 	}
+
+// 	buf := make([]byte, uintSize+msgmax)
+// 	buffer := bytes.NewBuffer(buf)
+// 	buffer.Reset()
+// 	var err error
+// 	switch uintSize {
+// 	case 4:
+// 		err = binary.Write(buffer, binary.LittleEndian, uint32(msg.Mtype))
+// 	case 8:
+// 		err = binary.Write(buffer, binary.LittleEndian, uint64(msg.Mtype))
+// 	}
+// 	if err != nil {
+// 		return fmt.Errorf("Can't write binary: %v", err)
+// 	}
+// 	buffer.Write(msg.Mtext)
+// 	_, _, errno := syscall.Syscall6(syscall.SYS_MSGSND,
+// 		uintptr(qid),
+// 		uintptr(unsafe.Pointer(&buf[0])),
+// 		uintptr(len(msg.Mtext)),
+// 		uintptr(flags),
+// 		0,
+// 		0,
+// 	)
+// 	if errno != 0 {
+// 		return errno
+// 	}
+// 	return nil
+// }
+
+// PrepareMsg creates a buffer containing the message to send
+func PrepareMsg(msg *Msgbuf) (*bytes.Buffer, error) {
 	if len(msg.Mtext) > msgmax {
-		return fmt.Errorf("mtext is too large, %d > %d", len(msg.Mtext), msgmax)
+		return nil, fmt.Errorf("mtext is too large, %d > %d", len(msg.Mtext), msgmax)
 	}
 
 	buf := make([]byte, uintSize+msgmax)
@@ -25,13 +68,20 @@ func Msgsnd(qid uint, msg *Msgbuf, flags uint) error {
 		err = binary.Write(buffer, binary.LittleEndian, uint64(msg.Mtype))
 	}
 	if err != nil {
-		return fmt.Errorf("Can't write binary: %v", err)
+		return nil, fmt.Errorf("Can't write binary: %v", err)
 	}
 	buffer.Write(msg.Mtext)
+
+	return buffer, nil
+
+}
+
+//MsgsndPrepared sends a prepared message using the msgsnd() syscall
+func MsgsndPrepared(qid uint, len int, buffer *bytes.Buffer, flags uint) error {
 	_, _, errno := syscall.Syscall6(syscall.SYS_MSGSND,
 		uintptr(qid),
-		uintptr(unsafe.Pointer(&buf[0])),
-		uintptr(len(msg.Mtext)),
+		uintptr(unsafe.Pointer(&buffer.Bytes()[0])),
+		uintptr(len),
 		uintptr(flags),
 		0,
 		0,
@@ -40,4 +90,5 @@ func Msgsnd(qid uint, msg *Msgbuf, flags uint) error {
 		return errno
 	}
 	return nil
+
 }

--- a/msgsnd.go
+++ b/msgsnd.go
@@ -18,39 +18,6 @@ func Msgsnd(qid uint, msg *Msgbuf, flags uint) error {
 	return MsgsndPrepared(qid, len(msg.Mtext), buffer, flags)
 }
 
-
-// 	if len(msg.Mtext) > msgmax {
-// 		return fmt.Errorf("mtext is too large, %d > %d", len(msg.Mtext), msgmax)
-// 	}
-
-// 	buf := make([]byte, uintSize+msgmax)
-// 	buffer := bytes.NewBuffer(buf)
-// 	buffer.Reset()
-// 	var err error
-// 	switch uintSize {
-// 	case 4:
-// 		err = binary.Write(buffer, binary.LittleEndian, uint32(msg.Mtype))
-// 	case 8:
-// 		err = binary.Write(buffer, binary.LittleEndian, uint64(msg.Mtype))
-// 	}
-// 	if err != nil {
-// 		return fmt.Errorf("Can't write binary: %v", err)
-// 	}
-// 	buffer.Write(msg.Mtext)
-// 	_, _, errno := syscall.Syscall6(syscall.SYS_MSGSND,
-// 		uintptr(qid),
-// 		uintptr(unsafe.Pointer(&buf[0])),
-// 		uintptr(len(msg.Mtext)),
-// 		uintptr(flags),
-// 		0,
-// 		0,
-// 	)
-// 	if errno != 0 {
-// 		return errno
-// 	}
-// 	return nil
-// }
-
 // PrepareMsg creates a buffer containing the message to send
 func PrepareMsg(msg *Msgbuf) (*bytes.Buffer, error) {
 	if len(msg.Mtext) > msgmax {

--- a/msgsnd_test.go
+++ b/msgsnd_test.go
@@ -113,3 +113,26 @@ func ExampleMsgsnd() {
 	// Output:
 	// received message: "bonjour"
 }
+
+func TestPrepareMsg(t *testing.T) {
+	// Message too long
+	msg := ipc.Msgbuf{Mtype: 1234}
+	msg.Mtext = make([]byte, ipc.Msgmax() + 1)
+	ipcMsg, err := ipc.PrepareMsg(&msg)
+	if ipcMsg != nil {
+		t.Error("Expected ipcMsg to be <nil>")
+	}
+	if err == nil {
+		t.Error("Expected an error for len > msgmax")
+	}
+
+	// all Ok
+	msg.Mtext = []byte("test text")
+	ipcMsg, err = ipc.PrepareMsg(&msg)
+	if ipcMsg == nil {
+		t.Error("Expected an ipc message")
+	}
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}

--- a/msgsnd_test.go
+++ b/msgsnd_test.go
@@ -42,14 +42,15 @@ func TestMsgsnd(t *testing.T) {
 		}(qid)
 		mtext := "hello"
 		done := make(chan struct{})
+		errChan := make(chan error, 1)
 		go func() {
 			qbuf := &ipc.Msgbuf{Mtype: 12}
 			err := ipc.Msgrcv(qid, qbuf, 0)
 			if err != nil {
-				t.Fatal(err)
+				errChan <- err
 			}
 			if want, got := mtext, string(qbuf.Mtext); want != got {
-				t.Fatalf("want %#v, got %#v", want, got)
+				errChan <- fmt.Errorf("want %#v, got %#v", want, got)
 			}
 			fmt.Printf("Received: %s\n", string(qbuf.Mtext))
 			done <- struct{}{}
@@ -63,6 +64,8 @@ func TestMsgsnd(t *testing.T) {
 
 		select {
 		case <-done:
+		case err := <-errChan:
+			t.Fatal(err)
 		case <-time.After(time.Second):
 			t.Fatal("blocked for too long")
 		}
@@ -115,24 +118,38 @@ func ExampleMsgsnd() {
 }
 
 func TestPrepareMsg(t *testing.T) {
-	// Message too long
-	msg := ipc.Msgbuf{Mtype: 1234}
-	msg.Mtext = make([]byte, ipc.Msgmax() + 1)
-	ipcMsg, err := ipc.PrepareMsg(&msg)
-	if ipcMsg != nil {
-		t.Error("Expected ipcMsg to be <nil>")
-	}
-	if err == nil {
-		t.Error("Expected an error for len > msgmax")
+	cases := []struct {
+		label   string
+		mtext   []byte
+		wantErr bool
+	}{
+		{"message too long", make([]byte, ipc.Msgmax()+1), true},
+		{"ok", []byte("test text"), false},
 	}
 
-	// all Ok
-	msg.Mtext = []byte("test text")
-	ipcMsg, err = ipc.PrepareMsg(&msg)
-	if ipcMsg == nil {
-		t.Error("Expected an ipc message")
+	for _, tt := range cases {
+		msg := ipc.Msgbuf{
+			Mtype: 1234,
+			Mtext: tt.mtext,
+		}
+		ipcMsg, err := ipc.PrepareMsg(&msg)
+
+		if tt.wantErr {
+			if ipcMsg != nil {
+				t.Errorf("case %s: Expected ipcMsg to be <nil>", tt.label)
+			}
+			if err == nil {
+				t.Errorf("case %s: Expected an error", tt.label)
+			}
+		} else {
+			if ipcMsg == nil {
+				t.Errorf("case %s: Expected an ipc message", tt.label)
+			}
+			if err != nil {
+				t.Errorf("case %s: Expected no error, got %v", tt.label, err)
+			}
+
+		}
 	}
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
+
 }


### PR DESCRIPTION
We were using your package successfully before migrating to go 1.14. This version often breaks the ipc.Msgsnd function when used under high frequency and flags 0 (which is a blocking call). As a workaround, we are now using a for cycle where we issue an ipc.Msgsnd with flag ipc.IPC_NOWAIT and if the resulting error is a syscall.EAGAIN we sleep for a bit and try again. This workaround works, but it has the inconvenient of being pretty heavy on memory allocation. This is due to the buffer allocation in ipc.Msgsnd. I have created this repository: https://github.com/peano88/test-ipc-memory to show that 

1.  with go1.14 we have often an "interrupted system call" ( at least on a CentOs, just run the waitFail/ipc_wait_fail.go a couple of times: it should be enough) 
2. the memory allocation of the no wait alternatives is pretty high (there is a screenshot of the memprofile in the noWait folder). 

We then worked on a feasible solution, which is the subject of this pull request: it consists of preparing the buffer once and try to send it afterwards. The memprofile in noWaitModified folder of the above repository shows the difference. As a plus, I solved a couple of go vet issues in the test file. 