### PR TITLE
Add MsgctlExtend() and fix bug around Mtype read

### DIFF
--- a/common.go
+++ b/common.go
@@ -12,16 +12,19 @@ const (
 	IPC_NOWAIT = 04000 // Return error on wait.
 
 	// Control commands for `msgctl', `semctl', and `shmctl'.
-	IPC_RMID = 0 // Remove identifier.
-	IPC_SET  = 1 // Set `ipc_perm' options.
-	IPC_STAT = 2 // Get `ipc_perm' options.
-	IPC_INFO = 3 // See ipcs.
+	IPC_RMID     = 0  // Remove identifier.
+	IPC_SET      = 1  // Set `ipc_perm' options.
+	IPC_STAT     = 2  // Get `ipc_perm' options.
+	IPC_INFO     = 3  // See ipcs.
+	MSG_STAT     = 11 // See https://man7.org/linux/man-pages/man2/msgctl.2.html, msqid is an index rather than a msg queue id
+	MSG_INFO     = 12 // See https://man7.org/linux/man-pages/man2/msgctl.2.html
+	MSG_STAT_ANY = 13 // See https://lore.kernel.org/linux-api/20180215162458.10059-4-dave@stgolabs.net/
 
 	// Special key values.
 	IPC_PRIVATE = 0 // Private key. NOTE: this value is of type __key_t, i.e., ((__key_t) 0)
 )
 
-var msgmax = 8192  // default size, will be overriden during init to match system msgmax
+var msgmax = 8192                // default size, will be overriden during init to match system msgmax
 var uintSize = bits.UintSize / 8 // size of a uint, arch dependent
 
 type Msgbuf struct {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/siadat/ipc
 
 go 1.14
+
+require github.com/stretchr/testify v1.6.1

--- a/init_linux.go
+++ b/init_linux.go
@@ -1,31 +1,10 @@
 package ipc
 
-import (
-	"syscall"
-	"unsafe"
-)
-
 func init() {
-	var buf msginfo
-	_, _, err := syscall.Syscall(
-		syscall.SYS_MSGCTL, 
-		0, 
-		uintptr(IPC_INFO), 
-		uintptr(unsafe.Pointer(&buf)))
-	if err != 0 {
-		return // can't read current msg info, leave defaults
+	var buf Msginfo
+	_, err := MsgctlExtend(0, IPC_INFO, &buf)
+	if nil != err {
+		return
 	}
-
-	msgmax = int(buf.msgmax)
-}
-
-type msginfo struct {
-    msgpool int32
-    msgmap int32
-    msgmax int32
-    msgmnb int32
-    msgmni int32
-    msgssz int32
-    msgtql int32
-    msgseg uint16
+	msgmax = int(buf.Msgmax)
 }

--- a/msgctl.go
+++ b/msgctl.go
@@ -1,9 +1,95 @@
 package ipc
 
 import (
+	"errors"
 	"fmt"
 	"syscall"
+	"time"
+	"unsafe"
 )
+
+// Permission define the Linux permission for a specific queue,
+// private data is required to read/write buffer of constant length
+type Permission struct {
+	Key     uint32
+	Uid     uint32
+	Gid     uint32
+	Cuid    uint32
+	Cgid    uint32
+	Mode    uint16
+	pad1    uint16
+	Seq     uint16
+	pad2    uint16
+	unused1 uint64
+	unused2 uint64
+}
+
+// MsqidDS struct type define one of the buffer for MsgctlExtend
+type MsqidDS struct {
+	MsgPerm   Permission
+	MsgStime  time.Time
+	MsgRtime  time.Time
+	MsgCtime  time.Time
+	MsgCbytes uint64
+	MsgQnum   uint64
+	MsgQbytes uint64
+	MsglSpid  uint32
+	MsglRpid  uint32
+}
+
+// Msginfo struct type define one of the buffer for MsgctlExtend
+type Msginfo struct {
+	Msgpool int32
+	Msgmap  int32
+	Msgmax  int32
+	Msgmnb  int32
+	Msgmni  int32
+	Msgssz  int32
+	Msgtql  int32
+	Msgseg  uint16
+}
+
+type ipctime uint64
+
+// msqidds internal data for buffer conversion
+type msqidds struct {
+	msgPerm   Permission
+	msgStime  ipctime
+	msgRtime  ipctime
+	msgCtime  ipctime
+	msgCbytes uint64
+	msgQnum   uint64
+	msgQbytes uint64
+	msglSpid  uint32
+	msglRpid  uint32
+	unused    [8]uint8
+}
+
+// convertBuffer from private to public data conversion
+func (m *msqidds) convertBuffer(r *MsqidDS) {
+	r.MsgPerm = m.msgPerm
+	r.MsgStime = time.Unix(int64(0), int64(m.msgStime))
+	r.MsgRtime = time.Unix(int64(0), int64(m.msgRtime))
+	r.MsgCtime = time.Unix(int64(0), int64(m.msgCtime))
+	r.MsgCbytes = m.msgCbytes
+	r.MsgQnum = m.msgQnum
+	r.MsgQbytes = m.msgQbytes
+	r.MsglSpid = m.msglSpid
+	r.MsglRpid = m.msglRpid
+}
+
+// convertBuffer from public to private data conversion
+func (m *MsqidDS) convertBuffer(r *msqidds) {
+	r.msgPerm = m.MsgPerm
+	r.msgStime = ipctime(m.MsgStime.Nanosecond())
+	r.msgRtime = ipctime(m.MsgRtime.Nanosecond())
+	r.msgCtime = ipctime(m.MsgCtime.Nanosecond())
+	r.msgCbytes = m.MsgCbytes
+	r.msgQnum = m.MsgQnum
+	r.msgQbytes = m.MsgQbytes
+	r.msglSpid = m.MsglSpid
+	r.msglRpid = m.MsglRpid
+}
 
 // Msgctl calls the msgctl() syscall.
 // FIXME: we are not passing the buf argument, see msgctl(2).
@@ -17,4 +103,49 @@ func Msgctl(qid uint, cmd int) error {
 		return err
 	}
 	return nil
+}
+
+// MsgctlExtend calls the msgctl() syscall including all behaviour.
+// MSG_STAT and MSG_STAT_ANY returns the identifier of the queue whose index was given in msqid.
+func MsgctlExtend(qid uint, cmd int, buf interface{}) (int, error) {
+	var ret uintptr
+	var errno syscall.Errno
+	switch cmd {
+	case IPC_RMID:
+		return 0, Msgctl(qid, cmd)
+	case IPC_SET, IPC_STAT, MSG_STAT, MSG_STAT_ANY:
+		convertedBuffer, ok := buf.(*MsqidDS)
+		if !ok {
+			return 0, errors.New("Wrong buffer type: required *MsqidDS type")
+		}
+		var realBuffer msqidds
+		if cmd == IPC_SET {
+			convertedBuffer.convertBuffer(&realBuffer)
+		}
+		ret, _, errno = syscall.Syscall(
+			syscall.SYS_MSGCTL,
+			uintptr(qid),
+			uintptr(cmd),
+			uintptr(unsafe.Pointer(&realBuffer)))
+		if errno != 0 {
+			return 0, syscall.Errno(errno)
+		}
+		realBuffer.convertBuffer(buf.(*MsqidDS))
+	case IPC_INFO, MSG_INFO:
+		_, ok := buf.(*Msginfo)
+		if !ok {
+			return 0, errors.New("Wrong buffer type: required *Msginfo type")
+		}
+		ret, _, errno = syscall.Syscall(
+			syscall.SYS_MSGCTL,
+			0,
+			uintptr(cmd),
+			uintptr(unsafe.Pointer(buf.(*Msginfo))))
+		if errno != 0 {
+			return 0, syscall.Errno(errno)
+		}
+	default:
+		return 0, fmt.Errorf("cmd [%d] is not a valid control command", cmd)
+	}
+	return int(ret), nil
 }

--- a/msgctl_test.go
+++ b/msgctl_test.go
@@ -1,23 +1,29 @@
 package ipc_test
 
 import (
+	"log"
 	"math/rand"
+	"os"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/siadat/ipc"
+	"github.com/stretchr/testify/assert"
 )
 
+func randomGen() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
 func TestMsgctl(t *testing.T) {
-	randomGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 	cases := []struct {
 		path string
 		id   uint32
 		perm int
 	}{
-		{".", randomGen.Uint32(), 0600},
-		{"/dev/null", randomGen.Uint32(), 0600},
+		{".", randomGen().Uint32(), 0600},
+		{"/dev/null", randomGen().Uint32(), 0600},
 	}
 
 	for _, tt := range cases {
@@ -42,6 +48,359 @@ func TestMsgctl(t *testing.T) {
 		_, err = ipc.Msgget(key, tt.perm)
 		if want, got := syscall.ENOENT, err; want != got {
 			t.Fatalf("want %q, got %v", want, got)
+		}
+	}
+}
+
+func TestMsgctlExtend(t *testing.T) {
+	tryCreateQueue := func() uint {
+		limit := 1024
+		for i := 0; i < limit; i++ {
+			key, err := ipc.Ftok(".", uint(randomGen().Uint32()))
+			if err != nil {
+				continue
+			}
+			qid, err := ipc.Msgget(key, 0600|ipc.IPC_CREAT)
+			if err != nil {
+				continue
+			}
+			return qid
+		}
+		t.Fatalf("Fails to create random queue")
+		return 0
+	}
+	deleteQueue := func(qid uint) {
+		assert.NoError(t, ipc.Msgctl(qid, ipc.IPC_RMID))
+	}
+	type args struct {
+		qid  uint
+		cmd  int
+		mbuf interface{}
+	}
+	lastMsqidDS := ipc.MsqidDS{}
+	lastMsginfo := ipc.Msginfo{}
+	noSetup := func(args) {}
+	noTest := func(args, int) {}
+	tests := []struct {
+		name    string
+		args    args
+		setup   func(args)
+		test    func(args, int)
+		wantErr bool
+	}{
+		{
+			"IPC_RMID: works",
+			args{
+				tryCreateQueue(),
+				ipc.IPC_RMID,
+				nil,
+			},
+			noSetup,
+			func(x args, ret int) {
+				if _, err := ipc.Msgget(x.qid, 0600); err != syscall.ENOENT {
+					t.Fatalf("Queue still exist over %q with error %s", x.qid, err.Error())
+				}
+			},
+			false,
+		},
+		{
+			"IPC_STAT: works",
+			args{
+				tryCreateQueue(),
+				ipc.IPC_STAT,
+				&lastMsqidDS,
+			},
+			func(x args) {
+				buf := &ipc.Msgbuf{}
+				buf.Mtype = 1
+				buf.Mtext = []byte("payload")
+				for i := 0; i < 42; i++ {
+					assert.NoError(t,
+						ipc.Msgsnd(x.qid, buf, ipc.IPC_NOWAIT))
+				}
+			},
+			func(x args, ret int) {
+				defer deleteQueue(x.qid)
+				now := time.Now().UnixNano()
+				assert.Equal(t, 42*len("payload"), int(lastMsqidDS.MsgCbytes))
+				assert.Equal(t, 42, int(lastMsqidDS.MsgQnum))
+				assert.Less(t, 0, int(lastMsqidDS.MsgQbytes))
+				assert.Less(t, int64(lastMsqidDS.MsgStime.Nanosecond()), now)
+				assert.Equal(t, int64(0), int64(lastMsqidDS.MsgRtime.Nanosecond()))
+				assert.Less(t, int64(lastMsqidDS.MsgCtime.Nanosecond()), now)
+				assert.Equal(t, os.Getpid(), int(lastMsqidDS.MsglSpid))
+				assert.Equal(t, 0, int(lastMsqidDS.MsglRpid))
+				assert.Equal(t, os.Geteuid(), int(lastMsqidDS.MsgPerm.Uid))
+				assert.Equal(t, os.Getegid(), int(lastMsqidDS.MsgPerm.Gid))
+			},
+			false,
+		},
+		{
+			"IPC_SET: change maximum number of bytes allowed in queue",
+			args{
+				tryCreateQueue(),
+				ipc.IPC_SET,
+				&lastMsqidDS,
+			},
+			func(x args) {
+				lastMsqidDS.MsgQbytes >>= 1
+			},
+			func(x args, ret int) {
+				defer deleteQueue(x.qid)
+				var localBuf ipc.MsqidDS
+				_, err := ipc.MsgctlExtend(x.qid, ipc.IPC_STAT, &localBuf)
+				assert.NoError(t, err)
+				// Queue has a new size in term of allowed bytes
+				assert.Equal(t, lastMsqidDS.MsgQbytes, localBuf.MsgQbytes)
+			},
+			false,
+		},
+		{
+			"IPC_SET && MSG_STAT_ANY: make a queue not accessible for a user and read it anyway",
+			args{
+				tryCreateQueue(),
+				ipc.IPC_SET,
+				&lastMsqidDS,
+			},
+			func(x args) {
+				lastMsqidDS.MsgPerm.Mode ^= lastMsqidDS.MsgPerm.Mode
+			},
+			func(x args, ret int) {
+				defer deleteQueue(x.qid)
+				var localBuf ipc.MsqidDS
+				// Queue is not more accessible for current user
+				_, err := ipc.MsgctlExtend(x.qid, ipc.IPC_STAT, &localBuf)
+				assert.Equal(t, syscall.EACCES, err)
+				// Using MSG_STAT_ANY is possible to access without check the permissions:
+				// as long as the `cat /proc/sysvipc/msg` does for any users
+				_, err = ipc.MsgctlExtend(x.qid, ipc.MSG_STAT_ANY, &localBuf)
+				assert.NoError(t, err)
+			},
+			false,
+		},
+		{
+			"IPC_SET: error, wrong type",
+			args{
+				0,
+				ipc.IPC_SET,
+				&lastMsginfo,
+			},
+			noSetup,
+			noTest,
+			true,
+		},
+		{
+			"IPC_INFO: works",
+			args{
+				0,
+				ipc.IPC_INFO,
+				&lastMsginfo,
+			},
+			func(x args) {},
+			func(x args, ret int) {
+				assert.Less(t, 0, int(lastMsginfo.Msgpool))
+				assert.Less(t, 0, int(lastMsginfo.Msgmap))
+				assert.Less(t, 0, int(lastMsginfo.Msgmax))
+				assert.Less(t, 0, int(lastMsginfo.Msgmnb))
+				assert.Less(t, 0, int(lastMsginfo.Msgmni))
+				assert.Less(t, 0, int(lastMsginfo.Msgssz))
+				assert.Less(t, 0, int(lastMsginfo.Msgtql))
+				assert.Less(t, 0, int(lastMsginfo.Msgseg))
+			},
+			false,
+		},
+		{
+			"IPC_INFO: error, wrong type",
+			args{
+				0,
+				ipc.IPC_INFO,
+				&lastMsqidDS,
+			},
+			noSetup,
+			noTest,
+			true,
+		},
+		{
+			"MSG_INFO: works",
+			args{
+				0,
+				ipc.MSG_INFO,
+				&lastMsginfo,
+			},
+			noSetup,
+			func(x args, ret int) {
+				assert.Less(t, 0, int(lastMsginfo.Msgpool))
+				assert.LessOrEqual(t, 0, int(lastMsginfo.Msgmap))
+				assert.Less(t, 0, int(lastMsginfo.Msgmax))
+				assert.Less(t, 0, int(lastMsginfo.Msgmnb))
+				assert.Less(t, 0, int(lastMsginfo.Msgmni))
+				assert.Less(t, 0, int(lastMsginfo.Msgssz))
+				assert.LessOrEqual(t, 0, int(lastMsginfo.Msgtql))
+				assert.Less(t, 0, int(lastMsginfo.Msgseg))
+			},
+			false,
+		},
+		{
+			"MSG_INFO: error, wrong type",
+			args{
+				0,
+				ipc.MSG_INFO,
+				&lastMsqidDS,
+			},
+			noSetup,
+			noTest,
+			true,
+		},
+		{
+			"MSG_INFO && MSG_STAT: loop over the existing messages to query",
+			args{
+				0,
+				ipc.MSG_INFO,
+				&lastMsginfo,
+			},
+			noSetup,
+			func(x args, ret int) {
+				// see https://man7.org/tlpi/code/online/dist/svmsg/svmsg_ls.c.html
+				for ret > 0 {
+					ret--
+					var localBuf ipc.MsqidDS
+					r, err := ipc.MsgctlExtend(uint(ret), ipc.MSG_STAT, &localBuf)
+					t.Logf("id = %d, ret = %d, key = %d", ret, r, localBuf.MsgPerm.Key)
+					if err != nil {
+						if err == syscall.EACCES || err == syscall.EINVAL {
+							continue
+						}
+						t.Fatalf("Unexcepted error %s", err.Error())
+					}
+				}
+			},
+			false,
+		},
+		{
+			"default case: error",
+			args{
+				0,
+				42,
+				nil,
+			},
+			noSetup,
+			noTest,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ret int
+			var err error
+			tt.setup(tt.args)
+			{
+				ret, err = ipc.MsgctlExtend(tt.args.qid, tt.args.cmd, tt.args.mbuf)
+				if err != nil != tt.wantErr {
+					if err == syscall.EIDRM {
+						t.Log("test [", tt.name, "] Required CAP_IPC_OWNER capability")
+						return
+					} else {
+						t.Errorf("MsgctlExtend() error = %v, wantErr %v", err, tt.wantErr)
+					}
+				}
+			}
+			tt.test(tt.args, ret)
+		})
+	}
+}
+
+func ExampleMsgctlExtend_IPC_INFO_IPC_STAT_IPC_SET_IPC_RMID() {
+	// fill Msginfo data structure
+	var bufInfo ipc.Msginfo
+	_, err := ipc.MsgctlExtend(0, ipc.IPC_INFO, &bufInfo)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// create an ftok key
+	key, err := ipc.Ftok("/dev/null", 20<<2)
+	if err != nil {
+		panic(err)
+	}
+
+	// create a new message queue
+	qid, err := ipc.Msgget(key, ipc.IPC_CREAT|ipc.IPC_EXCL|0600)
+	if err == syscall.EEXIST {
+		log.Fatalf("queue(key=0x%x) exists", key)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// remove queue in the end
+	defer func() {
+		_, err := ipc.MsgctlExtend(qid, ipc.IPC_RMID, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// send random number of message
+	send := func() error {
+		msg := &ipc.Msgbuf{Mtype: 12, Mtext: []byte("bonjour")}
+		return ipc.Msgsnd(qid, msg, 0)
+	}
+
+	N := rand.Intn(16) + 1
+	if len("bonjour") > int(bufInfo.Msgmax) ||
+		N*len("bonjour") > int(bufInfo.Msgmnb) {
+		log.Fatalf("Can't say 'bonjour' %d times", N)
+	}
+	for i := 0; i < N; i++ {
+		if err := send(); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// read MsqidDS data structure
+	var bufStat ipc.MsqidDS
+	_, err = ipc.MsgctlExtend(qid, ipc.IPC_STAT, &bufStat)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if N != int(bufStat.MsgQnum) {
+		log.Fatal("Mismatch number of messages currently on the message queue")
+	}
+	log.Printf("Sent 'bonjour' msg %d times", N)
+
+	bufStat.MsgPerm.Mode = 0400
+	// set queue in read only mode
+	_, err = ipc.MsgctlExtend(qid, ipc.IPC_SET, &bufStat)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// can't send data
+	if err = send(); err != syscall.EACCES {
+		log.Fatalf("Should be inaccessible %s", err.Error())
+	}
+}
+
+func ExampleMsgctlExtend_MSG_INFO_MSG_STAT() {
+
+	// fill Msginfo
+	var bufInfo ipc.Msginfo
+	ret, err := ipc.MsgctlExtend(0, ipc.MSG_INFO, &bufInfo)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// loop over messages
+	for ret > 0 {
+		ret--
+		var localBuf ipc.MsqidDS
+		r, err := ipc.MsgctlExtend(uint(ret), ipc.MSG_STAT, &localBuf)
+		log.Printf("id = %d, ret = %d, key = %d", ret, r, localBuf.MsgPerm.Key)
+		if err != nil {
+			if err == syscall.EACCES || err == syscall.EINVAL {
+				continue
+			}
+			log.Fatalf("Unexcepted error %s", err.Error())
 		}
 	}
 }

--- a/msgrcv.go
+++ b/msgrcv.go
@@ -27,19 +27,19 @@ func Msgrcv(qid uint, msg *Msgbuf, flags uint) error {
 	switch uintSize {
 	case 4:
 		var mtype uint32
-		err := binary.Write(buffer, binary.LittleEndian, &mtype)
+		err := binary.Read(buffer, binary.LittleEndian, &mtype)
 		if err != nil {
 			return fmt.Errorf("Can't write binary: %v", err)
 		}
 		msg.Mtype = uint(mtype)
 	case 8:
 		var mtype uint64
-		err := binary.Write(buffer, binary.LittleEndian, &mtype)
+		err := binary.Read(buffer, binary.LittleEndian, &mtype)
 		if err != nil {
 			return fmt.Errorf("Can't write binary: %v", err)
 		}
 		msg.Mtype = uint(mtype)
 	}
-	msg.Mtext = buf[uintSize:uintSize+int(lengthRead)]
+	msg.Mtext = buf[uintSize : uintSize+int(lengthRead)]
 	return nil
 }

--- a/msgrcv_test.go
+++ b/msgrcv_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/siadat/ipc"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMsgrcv(t *testing.T) {
@@ -58,6 +59,7 @@ func TestMsgrcv(t *testing.T) {
 		t.Errorf("Input = %v, want %v", qbuf.Mtext, input)
 	}
 
+	assert.Equal(t, 12, int(qbuf.Mtype))
 }
 
 func TestMsgrcvBlocks(t *testing.T) {


### PR DESCRIPTION
* MsgctlExtend() is fully compatible with linux msgctl definition.
* Bugfix within msgrcv.go: Mtype was write instead read.